### PR TITLE
Add context for background styles

### DIFF
--- a/src/Pages/Main.js
+++ b/src/Pages/Main.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Route, Routes } from "react-router-dom";
 import "./Main.css";
 import Home from "./HomePage/Home";
@@ -9,31 +9,42 @@ import SearchResults from "./SearchResultsPage/SearchResultsPage";
 import RecipeDetails from "./RecipeDetailsPage/RecipeDetails";
 import NoMatch from "./NoMatchPage";
 import SearchBarBS from "../components/SearchBar/SearchBarBS";
-import background from "../images/recipeezyhomepage.jpeg";
+import background from '../images/recipeezyhomepage.jpeg';
+import { BackgroundStylesContext } from "../contexts/BackgroundStylesContext";
 
 function Main() {
+  const [backgroundStyles, setBackgroundStyles] = useState({
+    height: '100vh',
+    width: '100vw',
+    backgroundSize: 'cover',
+    backgroundPosition: 'center center',
+    background: `url(${background})`,
+    backgroundAttachment: 'fixed',
+    position: "fixed",
+    zIndex: -1,
+  });
+
   return (
     <main
       className="main"
-      style={{
-        backgroundSize: "cover",
-        backgroundPosition: "center center",
-        background: `url(${background})`,
-        backgroundAttachment: "fixed",
-      }}
     >
-      <Routes>
-        <Route path="Recipeezy" element={<Home />}>
-          <Route index element={<SearchBarBS />} />
-          <Route path="grocerylist" element={<GroceryList />} />
-          <Route path="plannedmeals" element={<PlannedMeals />} />
-          <Route path="about" element={<About />} />
-          <Route path="results" element={<SearchResults />} />
-          <Route path="recipe/:recipetitle" element={<RecipeDetails />} />
+      <BackgroundStylesContext.Provider value={{ backgroundStyles, setBackgroundStyles }} > 
+        <div
+          style={{...backgroundStyles}}
+        />
+        <Routes>
+          <Route path="Recipeezy" element={<Home />}>
+            <Route index element={<SearchBarBS />} />
+            <Route path="grocerylist" element={<GroceryList />} />
+            <Route path="plannedmeals" element={<PlannedMeals />} />
+            <Route path="about" element={<About />} />
+            <Route path="results" element={<SearchResults />} />
+            <Route path="recipe/:recipetitle" element={<RecipeDetails />} />
+            <Route path="*" element={<NoMatch />} />
+          </Route>
           <Route path="*" element={<NoMatch />} />
-        </Route>
-        <Route path="*" element={<NoMatch />} />
-      </Routes>
+        </Routes>
+      </BackgroundStylesContext.Provider>
     </main>
   );
 }

--- a/src/Pages/SearchResultsPage/SearchResultsPage.js
+++ b/src/Pages/SearchResultsPage/SearchResultsPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import RecipeCardBSAdd from "../../components/RecipeCard/RecipeCardBSAdd";
 import { Col, Row } from "react-bootstrap";
 import SearchBarBS from "../../components/SearchBar/SearchBarBS";
@@ -7,9 +7,11 @@ import axios from "axios";
 import styles from "./SearchResultsPage.module.css";
 import key from "weak-key";
 import { useLocation } from "react-router-dom";
+import { BackgroundStylesContext } from '../../contexts/BackgroundStylesContext';
 
 const SearchResults = (props) => {
   const [searchData, setSearchData] = useState();
+  const { backgroundStyles, setBackgroundStyles } = useContext(BackgroundStylesContext);
 
   //TO GET PARAMS FROM URL
   const location = useLocation(); // to check if url is updated
@@ -32,11 +34,17 @@ const SearchResults = (props) => {
       )
       .then((res) => {
         setSearchData(res.data.hits);
+        if (backgroundStyles?.opacity !== '50%') {
+          setBackgroundStyles({
+            ...backgroundStyles,
+            opacity: '50%',
+          });
+        }
       })
       .catch((err) => {
         console.log(err);
       });
-  }, [location]);
+  }, [location, backgroundStyles, setBackgroundStyles, q]);
   console.log(styles.altbackground);
   return (
     <div>

--- a/src/contexts/BackgroundStylesContext.js
+++ b/src/contexts/BackgroundStylesContext.js
@@ -1,0 +1,15 @@
+import { createContext } from "react";
+
+export const BackgroundStylesContext = createContext({
+    styles: {
+        height: '',
+        width: '',
+        backgroundSize: '',
+        backgroundPosition: '',
+        background: '',
+        backgroundAttachment: '',
+        position: '',
+        zIndex: 0,
+    },
+    setStyles: () => {},
+})


### PR DESCRIPTION
Hello Brian, this PR should fix the issues you're facing with the background image not changing opacity. 

Initially, you had a `<main>` with a background image, and you were trying to put a `<div>` with opacity 50% over it. This would not work because the **opacity needs to be applied to the same `<div>` that the background image is in**.

Instead, the `<div>` containing the background image needs to exist on its own in the background, and the other elements in your app should lay on top of it (like you briefly mentioned last night). 

On top of that, since you need to change the background image opacity conditionally, there has to be a way to manipulate the `styles` of the `<div>` containing the background image. What I have done here is to create a `context` (see [this guide](https://reactjs.org/docs/context.html#updating-context-from-a-nested-component)) and allow the search results page to set the opacity to the background image once search results are returned. 

Take a look at whether you understand the changes. We can discuss further on Thursday if you need to make more clarifications.